### PR TITLE
Fix problem when reorder object of json file

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,10 +94,7 @@ module.exports = (locales, pattern, buildDir, opts) => {
   }).then(newLocaleMaps => {
     return Promise.all(
       locales.map(locale => {
-        // If the default locale, overwrite the origin file
-        const localeMap = locale === defaultLocale
-          ? merge(oldLocaleMaps[locale], newLocaleMaps[locale])
-          : merge(newLocaleMaps[locale], oldLocaleMaps[locale])
+        const localeMap = merge(newLocaleMaps[locale], oldLocaleMaps[locale])
 
         const outputPath = path.resolve(buildDir, locale)
 


### PR DESCRIPTION
I think it is the same with the order of argument we pass in merge function. But if we place the new one first, result file will be reordered well. I faced this issue when I add new message and run script again. Correct me if I'm wrong :)  Anyway, I really appreciate this tool so much, it help me a lot by saving time correcting message manually. Thank you!!

Files I generated. En is default language

en.json
{
  **"homePage_title": "Home page",
  "homePage_slogan": "Slogan",**
  "topicPage_title": "Topic",
  "topic_filter_recents": "Recents",
  "topic_filter_favorites": "Favorites",
  "reaction_feel": "Feel",
  **"homePage_testing": "testing",
  "homePage_testing_2": "testing_2"**
}


vi.json
{
  **"homePage_title": "",
  "homePage_slogan": "",
  "homePage_testing": "",
  "homePage_testing_2": "",**
  "topicPage_title": "",
  "topic_filter_recents": "",
  "topic_filter_favorites": "",
  "reaction_feel": ""
}