### PR TITLE
Add options to change delimiter character

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,8 @@ const cli = meow(
       d: 'default-locale'
     },
     default: {
-      format: 'json'
+      format: 'json',
+      delimiter: '.'
     }
   }
 )

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ const cli = meow(
   -f, --format          json | yaml [default: json]
   -d, --default-locale  default locale
   --flat                json [default: true] | yaml [default: false]
+  --delimiter           json | yaml [default: .]
 
   Example
   $ extract-messages --locales=ja,en --output app/translations 'app/**/*.js'
@@ -22,7 +23,7 @@ const cli = meow(
 `,
   {
     boolean: ['flat'],
-    strings: ['output', 'locales', 'format'],
+    strings: ['output', 'locales', 'format', 'delimiter'],
     alias: {
       o: 'output',
       l: 'locales',

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const writeYaml = (outputPath, obj) => {
 
 const isJson = ext => ext === 'json'
 
-function loadLocaleFiles(locales, buildDir, ext) {
+function loadLocaleFiles(locales, buildDir, ext, opts) {
   const oldLocaleMaps = {}
 
   try {
@@ -44,7 +44,7 @@ function loadLocaleFiles(locales, buildDir, ext) {
       ? loadJsonFile.sync(file)
       : yaml.safeLoad(fs.readFileSync(file, 'utf8'), { json: true })
 
-    messages = flatten(messages)
+    messages = flatten(messages, { delimiter: opts.delimiter })
 
     oldLocaleMaps[locale] = {}
     for (const messageKey of Object.keys(messages)) {
@@ -88,7 +88,7 @@ module.exports = (locales, pattern, buildDir, opts) => {
 
   const { defaultLocale } = opts
 
-  const oldLocaleMaps = loadLocaleFiles(locales, buildDir, ext)
+  const oldLocaleMaps = loadLocaleFiles(locales, buildDir, ext, opts)
 
   return extractReactIntl(locales, pattern, {
     defaultLocale
@@ -102,7 +102,7 @@ module.exports = (locales, pattern, buildDir, opts) => {
 
         const fomattedLocaleMap = opts.flat
           ? sortKeys(localeMap, { deep: true })
-          : unflatten(sortKeys(localeMap))
+          : unflatten(sortKeys(localeMap), { delimiter: opts.delimiter })
 
         const fn = isJson(opts.format) ? writeJson : writeYaml
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const writeYaml = (outputPath, obj) => {
 
 const isJson = ext => ext === 'json'
 
-function loadLocaleFiles(locales, buildDir, ext, opts) {
+function loadLocaleFiles(locales, buildDir, ext, delimiter) {
   const oldLocaleMaps = {}
 
   try {
@@ -44,7 +44,7 @@ function loadLocaleFiles(locales, buildDir, ext, opts) {
       ? loadJsonFile.sync(file)
       : yaml.safeLoad(fs.readFileSync(file, 'utf8'), { json: true })
 
-    messages = flatten(messages, { delimiter: opts.delimiter })
+    messages = flatten(messages, { delimiter })
 
     oldLocaleMaps[locale] = {}
     for (const messageKey of Object.keys(messages)) {
@@ -78,9 +78,8 @@ module.exports = (locales, pattern, buildDir, opts) => {
 
   const jsonOpts = { format: 'json', flat: true }
   const yamlOpts = { format: 'yaml', flat: false }
-  const defautlOpts = opts && opts.format && !isJson(opts.format)
-    ? yamlOpts
-    : jsonOpts
+  const defautlOpts =
+    opts && opts.format && !isJson(opts.format) ? yamlOpts : jsonOpts
 
   opts = Object.assign({ defaultLocale: 'en' }, defautlOpts, opts)
 
@@ -88,7 +87,9 @@ module.exports = (locales, pattern, buildDir, opts) => {
 
   const { defaultLocale } = opts
 
-  const oldLocaleMaps = loadLocaleFiles(locales, buildDir, ext, opts)
+  const delimiter = opts.delimiter ? opts.delimiter : '.'
+
+  const oldLocaleMaps = loadLocaleFiles(locales, buildDir, ext, delimiter)
 
   return extractReactIntl(locales, pattern, {
     defaultLocale
@@ -96,13 +97,14 @@ module.exports = (locales, pattern, buildDir, opts) => {
     return Promise.all(
       locales.map(locale => {
         // If the default locale, overwrite the origin file
-        const localeMap = locale === defaultLocale
-          ? merge(oldLocaleMaps[locale], newLocaleMaps[locale])
-          : merge(newLocaleMaps[locale], oldLocaleMaps[locale])
+        const localeMap =
+          locale === defaultLocale
+            ? merge(oldLocaleMaps[locale], newLocaleMaps[locale])
+            : merge(newLocaleMaps[locale], oldLocaleMaps[locale])
 
         const fomattedLocaleMap = opts.flat
           ? sortKeys(localeMap, { deep: true })
-          : unflatten(sortKeys(localeMap), { delimiter: opts.delimiter })
+          : unflatten(sortKeys(localeMap), { delimiter })
 
         const fn = isJson(opts.format) ? writeJson : writeYaml
 

--- a/test/json/__snapshots__/test.js.snap
+++ b/test/json/__snapshots__/test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`delimiter - nest 1`] = `
+Object {
+  "a.hello": "hello",
+  "a.world": "world",
+  "b.hello": "hello",
+  "b.world": "world",
+}
+`;
+
+exports[`delimiter - nest 2`] = `
+Object {
+  "a.hello": "",
+  "a.world": "",
+  "b.hello": "",
+  "b.world": "",
+}
+`;
+
 exports[`export json - nest 1`] = `
 Object {
   "a": Object {

--- a/test/json/test.js
+++ b/test/json/test.js
@@ -43,3 +43,15 @@ test('sort keys', async t => {
   t.snapshot(Object.keys(en))
   t.snapshot(Object.keys(ja))
 })
+
+test('delimiter - nest', async t => {
+  const tmp = tempy.directory()
+  await m(['en', 'ja'], 'test/fixtures/**/*.js', tmp, {
+    flat: false,
+    delimiter: '_'
+  })
+  const en = JSON.parse(fs.readFileSync(path.resolve(tmp, 'en.json'), 'utf8'))
+  const ja = JSON.parse(fs.readFileSync(path.resolve(tmp, 'ja.json'), 'utf8'))
+  t.snapshot(en)
+  t.snapshot(ja)
+})


### PR DESCRIPTION
Due to [this change of react-intl](https://github.com/yahoo/react-intl/wiki/Upgrade-Guide#user-content-flatten-messages-object), I think we should support an option for user to input delimiter by themselves. What do you think?