### PR TITLE
refactor: bump extract-react-intl to ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "messages"
   ],
   "dependencies": {
-    "extract-react-intl": "^0.5.2",
+    "extract-react-intl": "^0.6.0",
     "flat": "^4.0.0",
     "js-yaml": "^3.11.0",
     "load-json-file": "^5.0.0",
@@ -50,6 +50,7 @@
   "devDependencies": {
     "all-contributors-cli": "^4.11.1",
     "ava": "^0.25.0",
+    "babel-core": "^6.26.3",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.2",
     "pify": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,18 @@ This package will generate json or yaml files from a glob. It will generate one 
 
 ## Install
 
+This project has a peer dependency on `babel-core`.
+
+To use this with Babel 6, run
+
 ```
-$ npm install --save-dev extract-react-intl-messages
+$ npm install --save-dev extract-react-intl-messages babel-core
+```
+
+To use this with Babel 7, run
+
+```
+$ npm install --dave--dev extract-react-intl-messages babel-core@bridge @babel/core
 ```
 
 ## Usage

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,7 +449,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.17.0, babel-core@^6.24.1, babel-core@^6.26.0:
+babel-core@^6.17.0, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -472,6 +472,30 @@ babel-core@^6.17.0, babel-core@^6.24.1, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
 
 babel-generator@^6.1.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -1314,7 +1338,7 @@ debug@^2.2.0, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^2.3.3:
+debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1873,11 +1897,10 @@ extglob@^2.0.2, extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-react-intl@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/extract-react-intl/-/extract-react-intl-0.5.2.tgz#a5b5ef0301b65bf1b3782b482428fc2d2d859f50"
+extract-react-intl@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/extract-react-intl/-/extract-react-intl-0.6.0.tgz#1696c2ce05513d936272af4b6663700df8414b55"
   dependencies:
-    babel-core "^6.24.1"
     babel-plugin-react-intl "^2.3.1"
     glob "^7.1.1"
     lodash.merge "^4.6.1"
@@ -4172,6 +4195,10 @@ private@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
+private@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -4791,7 +4818,7 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 


### PR DESCRIPTION
This means it now has to pull in babel-core as a devDependency.

**What**: `extract-react-intl` is bumped to `^0.6.0`

**Why**: To support Babel 7.

**How**: `yarn add extract-react-intl@^0.6.0; yarn add --dev babel-core`

**Checklist**:

* [x] Documentation
* [ ] Tests  N/A
* [x] Ready to be merged
* [ ] Added myself to contributors table  N/A
