### PR TITLE
Handle keys that use numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = async (locales, pattern, buildDir, opts) => {
 
       const fomattedLocaleMap = opts.flat
         ? sortKeys(localeMap, { deep: true })
-        : unflatten(sortKeys(localeMap), { delimiter })
+        : unflatten(sortKeys(localeMap), { delimiter, object: true })
 
       const fn = isJson(opts.format) ? writeJson : writeYaml
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:

When calling unflatten, send in the option to not generated arrays for ids that end in numbers


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:

When using the auto id generator id's get get generated as numbers.  These will cause arrays to be built when using unflatten.  By sending in `object: true` the arrays won't be generated

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
