### PR TITLE
Adding support to extract messages from intl.formatMessage calls

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,7 @@ const cli = meow(
   --flat                json [default: true] | yaml [default: false]
   --delimiter           json | yaml [default: .]
   --module-name         module source name from where components are imported
+  --extractFromFormatMessageCall      If set to 'true', Command will extract the messages and IDs from 'intl.formatMessage' calls
 
   Example
   $ extract-messages --locales=ja,en --output app/translations 'app/**/*.js'
@@ -50,6 +51,9 @@ const cli = meow(
       },
       'module-name': {
         type: 'string'
+      },
+      extractFromFormatMessageCall: {
+        type: 'boolean'
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -80,13 +80,13 @@ module.exports = async (locales, pattern, buildDir, opts) => {
 
   const ext = isJson(opts.format) ? 'json' : 'yml'
 
-  const { defaultLocale, moduleName } = opts
+  const { defaultLocale, moduleName, extractFromFormatMessageCall } = opts
 
   const delimiter = opts.delimiter ? opts.delimiter : '.'
 
   const oldLocaleMaps = loadLocaleFiles(locales, buildDir, ext, delimiter)
 
-  const extractorOptions = { defaultLocale }
+  const extractorOptions = { defaultLocale, extractFromFormatMessageCall }
 
   if (moduleName) {
     extractorOptions.moduleSourceName = moduleName

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ $ extract-messages --help
   --default-locale   default locale [default: en]
   --delimiter        json | yaml [default: .]
   --module-name      module source name from where components are imported [default: react-intl]
+  --extractFromFormatMessageCall      If set to `true`, Command will extract the messages and IDs from `intl.formatMessage` calls
 
   Example
   $ extract-messages --locales=ja,en --output app/translations 'app/**/*.js'
@@ -177,6 +178,21 @@ Type: `string`<br>
 Default: `react-intl`
 
 Set from where _defineMessages_, `<FormatterMessage />` and `<FormattedHTML />` are imported.
+
+##### extractFromFormatMessageCall
+
+Type: `boolean`<br>
+Default: `react-intl`
+
+If the value is `true`, Extractor will extract the i18n message and ID from `intl.formatMessage` calls as well.
+i:e
+
+```
+intl.formatMessage({
+                id: 'Supported.file.types',
+                defaultMessage: 'Supported file types',
+            })
+```
 
 ## Contributors
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: Posible implementation for https://github.com/akameco/extract-react-intl-messages/issues/38 feature request 


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: Without these changes, Users can't generate locale ids and messages that are used in `intl.formatMessage` function calls as direct object argument.

i:e 

```javascript
Alert.error(intl.formatMessage({
                id: 'Supported.file.type',
                defaultMessage: 'Supported File Type.',
            }));
```
Above id (Supported.file.type) and message will not be available in generated locale file, Unless `extractFromFormatMessageCall` is set to true in `babel-plugin-react-intl` plugin configurations. 

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: Changes were done to pass the `extractFromFormatMessageCall` parameter to `babel-plugin-react-intl` configurations via the `extract-react-intl` library interfaces.

So that this PR depends on: https://github.com/akameco/extract-react-intl/pull/21

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
