### PR TITLE
Sort keys when output is not flat

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ const cli = meow(
   -f, --format          json | yaml [default: json]
   -d, --default-locale  default locale
   --flat                json [default: true] | yaml [default: false]
+  --sort-when-not-flat  keys are sorted even when flat option is false [default: false]
 
   Example
   $ extract-messages --locales=ja,en --output app/translations 'app/**/*.js'
@@ -23,6 +24,9 @@ const cli = meow(
   {
     flags: {
       flat: {
+        type: 'boolean'
+      },
+      'sort-when-not-flat': {
         type: 'boolean'
       },
       output: {

--- a/cli.js
+++ b/cli.js
@@ -15,7 +15,6 @@ const cli = meow(
   -f, --format          json | yaml [default: json]
   -d, --default-locale  default locale
   --flat                json [default: true] | yaml [default: false]
-  --sort-when-not-flat  keys are sorted even when flat option is false [default: false]
 
   Example
   $ extract-messages --locales=ja,en --output app/translations 'app/**/*.js'
@@ -24,9 +23,6 @@ const cli = meow(
   {
     flags: {
       flat: {
-        type: 'boolean'
-      },
-      'sort-when-not-flat': {
         type: 'boolean'
       },
       output: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ type Opts = {
   defaultLocale: string
   format?: string
   flat?: boolean
+  sortWhenNotFlat?: boolean
   [key: string]: unknown
 }
 
@@ -72,6 +73,7 @@ const extractMessage = async (
   {
     format = 'json',
     flat = isJson(format),
+    sortWhenNotFlat = false,
     defaultLocale = 'en',
     ...opts
   }: Opts = {
@@ -121,6 +123,8 @@ const extractMessage = async (
 
       const fomattedLocaleMap: object = flat
         ? sortKeys(localeMap, { deep: true })
+        : sortWhenNotFlat
+        ? sortKeys(unflatten(localeMap, { object: true }), { deep: true })
         : unflatten(sortKeys(localeMap), { object: true })
 
       const fn = isJson(format) ? writeJson : writeYaml

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ type Opts = {
   defaultLocale: string
   format?: string
   flat?: boolean
-  sortWhenNotFlat?: boolean
   [key: string]: unknown
 }
 
@@ -73,7 +72,6 @@ const extractMessage = async (
   {
     format = 'json',
     flat = isJson(format),
-    sortWhenNotFlat = false,
     defaultLocale = 'en',
     ...opts
   }: Opts = {
@@ -123,9 +121,7 @@ const extractMessage = async (
 
       const fomattedLocaleMap: object = flat
         ? sortKeys(localeMap, { deep: true })
-        : sortWhenNotFlat
-        ? sortKeys(unflatten(localeMap, { object: true }), { deep: true })
-        : unflatten(sortKeys(localeMap), { object: true })
+        : sortKeys(unflatten(localeMap, { object: true }), { deep: true })
 
       const fn = isJson(format) ? writeJson : writeYaml
 


### PR DESCRIPTION
**what**

出力がflatでない時に a-z 順ではなく、文字列の長さ順でソートされていたので、a-z 順で出力できるオプションを追加しました。

**Why**

展開する時に可読性が悪かったからです。

**How**:

オプションがついているときに、sortKeyをして返すようにしました。


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged 

