### PR TITLE
Fix absolute path needed in the run script example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ export const SubmitButton = () => {
 ### Run Script
 
 ```
-$ extract-messages -l=en,ja -o app/translations -d en --flat false 'app/**/!(*.test).js'
+$ extract-messages -l=en,ja -o app/translations -d en --flat false './app/**/!(*.test).js'
 ```
 
 ### Output


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:
In my case, this doesn't work:
```
$ extract-messages -l=en,ja -o app/translations -d en --flat false 'app/**/!(*.test).js'
```
But it works if i provide absolute path to input files regex:
```
$ extract-messages -l=en,ja -o app/translations -d en --flat false './app/**/!(*.test).js'
```


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ x] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
